### PR TITLE
Stop exposing ros-master port and better health check

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -172,10 +172,8 @@ services:
       options:
         mode: "non-blocking"
         max-buffer-size: "4m"
-    ports:
-      - "${STUDIO_ROS_MASTER_PORT:-11311}:11311"
     healthcheck:
-      test: ["CMD", "echo", ">", "/dev/tcp/localhost/11311"]
+      test: ["CMD", "rostopic", "list", "|", "grep", "-w", "'/rosout'", ">>", "/dev/null"]
       start_period: 3s
       interval: 10s
       timeout: 2s


### PR DESCRIPTION
- Remove exposed 11311, as it is currently stoping user from running roscore outside and since we don't have access to the topics in the host (yet), this is a pain
- Better healthcheck for roscore container
- Fixes: https://github.com/MOV-AI/movai-flow/issues/151
- https://movai.atlassian.net/browse/RP-1413

@xsoulp FYI. This should solve a bit of the issue you were mentioning.
@diasdm This should be enough for the sonarqube test?

- [x] Make sure you are opening from a **topic/feature/bugfix branch**
- [x] Ensure that the PR title represents the desired changes
- [x] Ensure that the PR description detail the desired changes
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue


[^note]:
    Put an `x` into the [ ] to show you have filled the information.
    The template comes from https://github.com/MOV-AI/.github/blob/master/.github/pull_request_template.md
    You can override it by creating .github/pull_request_template.md  in your own repository
