### PR TITLE
Bump to new release line 3.0.1

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-movai-flow (1.3.0-0) UNRELEASED; urgency=medium
+movai-flow (1.3.0-1) UNRELEASED; urgency=medium
 
   [ Alex Fernandes ]
   * add host_mode feature
@@ -70,5 +70,6 @@ movai-flow (1.3.0-0) UNRELEASED; urgency=medium
   * UNRELEASED
   * UNRELEASED
   * UNRELEASED
+  * UNRELEASED
 
- -- root <root@da780be7dfca>  Thu, 21 Jul 2022 12:33:16 +0000
+ -- root <root@a20539233c41>  Mon, 24 Oct 2022 08:37:14 +0000

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-movai-flow (1.3.0-1) UNRELEASED; urgency=medium
+movai-flow (3.0.1-0) UNRELEASED; urgency=medium
 
   [ Alex Fernandes ]
   * add host_mode feature


### PR DESCRIPTION
## Release 3.0.1
- R&D decided to change release major version from 1 to 3 for the following reasons
  - v1.x.y versions were holding developments, beta testing, internal QA
  - v2.x.y versions : non existing
  - v3.x.y versions: bumps 2 major numbers to align with our current enterprise product versioning which is based on the same architecture and which will be supported until v4.x.y is defined

---

- [x] Make sure you are opening from a **topic/feature/bugfix branch**
- [x] Ensure that the PR title represents the desired changes
- [x] Ensure that the PR description detail the desired changes
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
